### PR TITLE
Fix bug in FiberedMysql2Adapter_5_2 where steal! needed to update its owner to Fiber.current

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -9,5 +9,5 @@ appraise 'rails-5' do
 end
 
 appraise 'rails-6' do
-  gem 'rails', '~> 6.0'
+  gem 'rails', '~> 6.0.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - UNRELEASED
+### Fixed
+- Fixed bug with Rails 5+ adapter where connections that have `steal!` called on them were not having their owner updated to the current Fiber, which would then cause an exception when trying to expire the connection (this showed up with the Rails 5 `ConnectionPool::Reaper` that reaps unused connections)
+
 ## [0.1.0] - 2020-10-23
 ### Added
 - Added an adapter for Rails 4, 5, and 6.
@@ -11,4 +15,5 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Added TravisCI unit test pipeline.
 - Added coverage reports via Coveralls.
 
+[0.1.1]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.0..v0.1.1
 [0.1.0]: https://github.com/Invoca/fibered_mysql2/tree/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fibered_mysql2 (0.1.0)
+    fibered_mysql2 (0.1.1)
       em-synchrony (~> 1.0)
       rails (>= 4.2, < 7)
 

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -10,6 +10,6 @@ gem "pry", "~> 0.13"
 gem "pry-byebug", "~> 3.9"
 gem "rake", "~> 10.0"
 gem "rspec", "~> 3.0"
-gem "rails", "~> 6.0"
+gem "rails", "~> 6.0.0"
 
 gemspec path: "../"

--- a/lib/active_record/connection_adapters/fibered_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/fibered_mysql2_adapter.rb
@@ -49,6 +49,18 @@ module FiberedMysql2
         raise ::ActiveRecord::ActiveRecordError, "Cannot expire connection, it is not currently leased."
       end
     end
+
+    def steal!
+      if in_use?
+        if @owner != Fiber.current
+          pool.send :remove_connection_from_thread_cache, self, @owner
+
+          @owner = Fiber.current
+        end
+      else
+        raise ::ActiveRecord::ActiveRecordError, "Cannot steal connection, it is not currently leased."
+      end
+    end
   end
 
   class FiberedMysql2Adapter < ::ActiveRecord::ConnectionAdapters::EMMysql2Adapter

--- a/lib/fibered_mysql2/version.rb
+++ b/lib/fibered_mysql2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FiberedMysql2
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Fixed bug with Rails 5+ adapter where connections that have `steal!` called on them were not having their owner updated to the current Fiber, which would then cause an exception when trying to expire the connection (this showed up with the Rails 5 `ConnectionPool::Reaper` that reaps unused connections)

See [slack thread](https://invoca.slack.com/archives/CRGB17J59/p1612939922167700)