### PR TITLE
TECH-5885: ensure owner is a fiber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2021-06-16
+### Fixed
+- Added checking to be certain that @owner is never overwritten with a non-Fiber by another mixin.
+
 ## [0.1.1] - 2021-02-12
 ### Fixed
 - Fixed bug with Rails 5+ adapter where connections that have `steal!` called on them were not having their owner updated to the current Fiber, which would then cause an exception when trying to expire the connection (this showed up with the Rails 5 `ConnectionPool::Reaper` that reaps unused connections)
@@ -19,5 +23,6 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Added TravisCI unit test pipeline.
 - Added coverage reports via Coveralls.
 
+[0.1.2]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.1..v0.1.2
 [0.1.1]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.0..v0.1.1
 [0.1.0]: https://github.com/Invoca/fibered_mysql2/tree/v0.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'appraisal'
 gem 'bundler',    '~> 1.8'
 gem 'coveralls', require: false
+gem 'mimemagic',  '~> 0.3',     git: 'git@github.com:Invoca/mimemagic',                      ref: 'b084ce8d50c080f5a312156498be21a541fe72a2'
 gem 'mysql2',     '0.4.5'
 gem 'pry',        '~> 0.13'
 gem 'pry-byebug', '~> 3.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fibered_mysql2 (0.1.1)
+    fibered_mysql2 (0.1.2)
       em-synchrony (~> 1.0)
       rails (>= 4.2, < 7)
 
@@ -63,14 +63,14 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    appraisal (2.3.0)
+    appraisal (2.4.0)
       bundler
       rake
       thor (>= 0.14.0)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -82,14 +82,14 @@ GEM
     docile (1.3.2)
     em-synchrony (1.0.6)
       eventmachine (>= 1.0.0.beta.1)
-    erubi (1.9.0)
+    erubi (1.10.0)
     eventmachine (1.2.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
-    loofah (2.7.0)
+    loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -100,7 +100,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.2)
+    minitest (5.14.3)
     mysql2 (0.4.5)
     nio4r (2.5.4)
     nokogiri (1.10.10)
@@ -173,12 +173,12 @@ GEM
     thread_safe (0.3.6)
     tins (1.25.0)
       sync
-    tzinfo (1.2.7)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby
@@ -195,4 +195,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git@github.com:Invoca/mimemagic
+  revision: b084ce8d50c080f5a312156498be21a541fe72a2
+  ref: b084ce8d50c080f5a312156498be21a541fe72a2
+  specs:
+    mimemagic (0.3.5)
+
 PATH
   remote: .
   specs:
@@ -97,7 +104,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.3)
@@ -188,6 +194,7 @@ DEPENDENCIES
   bundler (~> 1.8)
   coveralls
   fibered_mysql2!
+  mimemagic (~> 0.3)!
   mysql2 (= 0.4.5)
   pry (~> 0.13)
   pry-byebug (~> 3.9)

--- a/lib/fibered_mysql2/version.rb
+++ b/lib/fibered_mysql2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FiberedMysql2
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/unit/fibered_mysql2_adapter_spec.rb
+++ b/spec/unit/fibered_mysql2_adapter_spec.rb
@@ -100,5 +100,13 @@ RSpec.describe FiberedMysql2::FiberedMysql2Adapter do
         end
       end
     end
+
+    context 'other mixins' do
+      it 'raises if @owner has been overwritten with a non-Fiber' do
+        adapter.instance_variable_set(:@owner, Thread.new { })
+
+        expect { adapter.expire }.to raise_exception(RuntimeError, /@owner must be a Fiber!/i)
+      end
+    end
   end
 end


### PR DESCRIPTION
TECH-5885

## [0.1.2] - 2021-06-16
### Fixed
- Added checking to be certain that `@owner` is never overwritten with a non-Fiber by another mixin.