### PR TITLE
WEB-5476: explicitly disable Reaper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - Unreleased
+### Fixed
+- Disable the ConnectionPool::Reaper in Rails 5 and 6 as it was in 4. This is important since it is
+threaded, not fibered.
+
 ## [0.1.3] - 2021-06-17
 ### Fixed
 - When checking that @owner is a Fiber, allow nil.
@@ -27,6 +32,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Added TravisCI unit test pipeline.
 - Added coverage reports via Coveralls.
 
+[0.1.4]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.3..v0.1.4
 [0.1.3]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.2..v0.1.3
 [0.1.2]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.1..v0.1.2
 [0.1.1]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.0..v0.1.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    fibered_mysql2 (0.1.3)
+    fibered_mysql2 (0.1.4.pre.1)
       em-synchrony (~> 1.0)
       rails (>= 4.2, < 7)
 

--- a/lib/fibered_mysql2/fibered_database_connection_pool.rb
+++ b/lib/fibered_mysql2/fibered_database_connection_pool.rb
@@ -173,6 +173,7 @@ module FiberedMysql2
 
     def initialize(connection_spec, *args, **keyword_args)
       connection_spec.config[:reaping_frequency] and raise "reaping_frequency is not supported (the ActiveRecord Reaper is thread-based)"
+      connection_spec.config[:reaping_frequency] = nil # starting in Rails 5, this defaults to 60 if not explicitly set
 
       super(connection_spec, *args, **keyword_args)
 

--- a/lib/fibered_mysql2/version.rb
+++ b/lib/fibered_mysql2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FiberedMysql2
-  VERSION = "0.1.3"
+  VERSION = "0.1.4.pre.1"
 end

--- a/spec/unit/fibered_database_connection_pool_spec.rb
+++ b/spec/unit/fibered_database_connection_pool_spec.rb
@@ -64,7 +64,7 @@ end
 
 RSpec.describe FiberedMysql2::FiberedDatabaseConnectionPool do
   let(:em_helper) { EmHelper.new }
-  
+
   before do
     allow(EM).to receive(:next_tick) { |&block| em_helper.queue_next_tick(&block) }
   end
@@ -346,6 +346,15 @@ RSpec.describe FiberedMysql2::FiberedDatabaseConnectionPool do
         queue.add(connection)
         em_helper.run_next_ticks
         expect(polled).to eq([connection])
+      end
+    end
+
+    context 'Reaper' do
+      subject { ActiveRecord::ConnectionAdapters::ConnectionPool.new(spec) }
+      it 'should be explicitly disabled and therefore not start up a reaper thread' do
+        threads_before = Thread.list
+        subject
+        expect(Thread.list - threads_before).to be_empty
       end
     end
   end


### PR DESCRIPTION
## [0.1.4] - Unreleased
### Fixed
- Disable the ConnectionPool::Reaper in Rails 5 and 6 as it was in 4. This is important since it is
threaded, not fibered.