### PR TITLE
Tech 9819 implement lazy transaction interface for rails 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - Unreleased
+### Added
+- Added support for Rails 6+ by adding knowledge of lazy transactions to the adapter.
+
 ## [0.1.5] - 2022-03-25
 ### Changed
 - Upgraded Bundler to 2.2.29 and Ruby to 2.7.5. Removed support for Rails 4.
@@ -37,6 +41,7 @@ threaded, not fibered.
 - Added TravisCI unit test pipeline.
 - Added coverage reports via Coveralls.
 
+[0.2.0]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.5..v0.2.0
 [0.1.5]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.4..v0.1.5
 [0.1.4]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.3..v0.1.4
 [0.1.3]: https://github.com/Invoca/fibered_mysql2/compare/v0.1.2..v0.1.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fibered_mysql2 (0.1.5)
+    fibered_mysql2 (0.2.0.jeb.1)
       em-synchrony (~> 1.0)
       rails (>= 5.2, < 7)
 

--- a/lib/fibered_mysql2/fibered_mysql2_connection_factory.rb
+++ b/lib/fibered_mysql2/fibered_mysql2_connection_factory.rb
@@ -47,6 +47,44 @@ module EM::Synchrony
               transaction
             end
           end
+
+          def materialize_transactions
+            return if @materializing_transactions
+            return unless @has_unmaterialized_transactions
+
+            @connection.lock.synchronize do
+              begin
+                @materializing_transactions = true
+                _current_stack.each { |t| t.materialize! unless t.materialized? }
+              ensure
+                @materializing_transactions = false
+              end
+              @has_unmaterialized_transactions = false
+            end
+          end
+
+          def commit_transaction
+            @connection.lock.synchronize do
+              transaction = _current_stack.last
+
+              begin
+                transaction.before_commit_records
+              ensure
+                _current_stack.pop
+              end
+
+              transaction.commit
+              transaction.commit_records
+            end
+          end
+
+          def rollback_transaction(transaction = nil)
+            @connection.lock.synchronize do
+              transaction ||= @_current_stack.pop
+              transaction.rollback
+              transaction.rollback_records
+            end
+          end
         end
       end
     end

--- a/lib/fibered_mysql2/fibered_mysql2_connection_factory.rb
+++ b/lib/fibered_mysql2/fibered_mysql2_connection_factory.rb
@@ -48,6 +48,9 @@ module EM::Synchrony
             end
           end
 
+          # Overriding the ActiveRecord::TransactionManager#materialize_transactions method to use
+          # fiber safe the _current_stack instead of the @stack instance variable. when marterializing
+          # transactions.
           def materialize_transactions
             return if @materializing_transactions
             return unless @has_unmaterialized_transactions
@@ -63,6 +66,9 @@ module EM::Synchrony
             end
           end
 
+          # Overriding the ActiveRecord::TransactionManager#commit_transaction method to use
+          # fiber safe the _current_stack instead of the @stack instance variable. when marterializing
+          # transactions.
           def commit_transaction
             @connection.lock.synchronize do
               transaction = _current_stack.last
@@ -78,9 +84,12 @@ module EM::Synchrony
             end
           end
 
+          # Overriding the ActiveRecord::TransactionManager#rollback_transaction method to use
+          # fiber safe the _current_stack instead of the @stack instance variable. when marterializing
+          # transactions.
           def rollback_transaction(transaction = nil)
             @connection.lock.synchronize do
-              transaction ||= @_current_stack.pop
+              transaction ||= _current_stack.pop
               transaction.rollback
               transaction.rollback_records
             end

--- a/lib/fibered_mysql2/version.rb
+++ b/lib/fibered_mysql2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FiberedMysql2
-  VERSION = "0.1.5"
+  VERSION = "0.2.0.jeb.1"
 end

--- a/spec/unit/fibered_mysql2_connection_factory_spec.rb
+++ b/spec/unit/fibered_mysql2_connection_factory_spec.rb
@@ -4,8 +4,11 @@ require_relative '../../lib/fibered_mysql2/fibered_mysql2_connection_factory'
 
 RSpec.describe FiberedMysql2::FiberedMysql2ConnectionFactory do
   let(:client) { double(Mysql2::EM::Client) }
-  
+  let(:stub_mysql_client_result) { Struct.new(:fields, :to_a).new([], []) }
+  let(:connection) { ActiveRecord::Base.connection }
+
   before do
+    allow(client).to receive(:query).and_return(stub_mysql_client_result)
     ActiveRecord::Base.establish_connection(
       :adapter => 'fibered_mysql2',
       :database => 'widgets',
@@ -15,40 +18,27 @@ RSpec.describe FiberedMysql2::FiberedMysql2ConnectionFactory do
   end
 
   context "transactions" do
-    it "should work with basic nesting" do
+    before do
       allow(client).to receive(:query_options) { {} }
       allow(client).to receive(:escape) { |query| query }
-      query_args = []
-      stub_mysql_client_result = Struct.new(:fields, :to_a).new([], [])
-      expect(client).to receive(:query) do |*args|
-        query_args << args
-        stub_mysql_client_result
-      end.at_least(1).times
       allow(client).to receive(:ping) { true }
       allow(client).to receive(:server_info).and_return({ version: "5.7.27" })
-
       allow(Mysql2::EM::Client).to receive(:new) { |config| client }
+    end
 
-      connection = ActiveRecord::Base.connection
+    it "should work with basic nesting" do
       if Rails::VERSION::MAJOR == 6
         allow(connection).to receive(:supports_lazy_transactions?).and_return(false)
       end
 
+
+      expect(client).to receive(:query).with("BEGIN").and_return(stub_mysql_client_result)
+      expect(client).to receive(:query).with("show tables").and_return(stub_mysql_client_result)
+      expect(client).to receive(:query).with("COMMIT").and_return(stub_mysql_client_result)
+
       connection.transaction do
         connection.exec_query("show tables")
       end
-      rails_specific_arg = case Rails::VERSION::MAJOR
-                           when 4
-                             "SET  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483, @@SESSION.sql_mode = 'STRICT_ALL_TABLES'"
-                           else
-                             "SET  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483"
-                           end
-      expect(query_args).to eq([
-                                   [rails_specific_arg],
-                                   ["BEGIN"],
-                                   ["show tables"],
-                                   ["COMMIT"]
-                               ])
     end
   end
 end

--- a/spec/unit/fibered_mysql2_connection_factory_spec.rb
+++ b/spec/unit/fibered_mysql2_connection_factory_spec.rb
@@ -3,41 +3,84 @@
 require_relative '../../lib/fibered_mysql2/fibered_mysql2_connection_factory'
 
 RSpec.describe FiberedMysql2::FiberedMysql2ConnectionFactory do
-  let(:client) { double(Mysql2::EM::Client) }
   let(:stub_mysql_client_result) { Struct.new(:fields, :to_a).new([], []) }
-  let(:connection) { ActiveRecord::Base.connection }
 
-  before do
-    allow(client).to receive(:query).and_return(stub_mysql_client_result)
-    ActiveRecord::Base.establish_connection(
-      :adapter => 'fibered_mysql2',
-      :database => 'widgets',
-      :username => 'root',
-      :pool => 10
-    )
+  describe "#fibered_mysql2_connection" do
+    let(:client) { double(Mysql2::EM::Client) }
+
+    context 'when fibered_mysql2 adapter is used' do
+      subject { ActiveRecord::Base.connection }
+
+      before do
+        expect(Mysql2::EM::Client).to receive(:new).and_return(client)
+        allow(client).to receive(:query_options) { {} }
+        allow(client).to receive(:server_info).and_return({ version: "5.7.27" })
+        allow(client).to receive(:ping) { true }
+        allow(client).to receive(:query).and_return(stub_mysql_client_result)
+        ActiveRecord::Base.establish_connection(
+          :adapter => 'fibered_mysql2',
+          :database => 'widgets',
+          :username => 'root',
+          :pool => 10
+        )
+      end
+
+      it { is_expected.to be_a(FiberedMysql2::FiberedMysql2Adapter) }
+    end
   end
 
-  context "transactions" do
+  describe "transactions" do
+    let(:client) { double(Mysql2::EM::Client) }
+    let(:logger) { Logger.new(STDOUT) }
+    let(:options) { [] }
+    let(:config) { {} }
+    let(:connection) { FiberedMysql2::FiberedMysql2Adapter.new(client, logger, options, config) }
+
     before do
       allow(client).to receive(:query_options) { {} }
       allow(client).to receive(:escape) { |query| query }
       allow(client).to receive(:ping) { true }
       allow(client).to receive(:server_info).and_return({ version: "5.7.27" })
-      allow(Mysql2::EM::Client).to receive(:new) { |config| client }
+      allow(client).to receive(:query).and_return(stub_mysql_client_result)
     end
 
     it "should work with basic nesting" do
-      if Rails::VERSION::MAJOR == 6
-        allow(connection).to receive(:supports_lazy_transactions?).and_return(false)
-      end
-
-
       expect(client).to receive(:query).with("BEGIN").and_return(stub_mysql_client_result)
       expect(client).to receive(:query).with("show tables").and_return(stub_mysql_client_result)
       expect(client).to receive(:query).with("COMMIT").and_return(stub_mysql_client_result)
 
       connection.transaction do
         connection.exec_query("show tables")
+      end
+    end
+
+    if Rails::VERSION::MAJOR >= 6
+      context "with an empty transaction" do
+        context "with lazy transactions disabled" do
+          before { connection.disable_lazy_transactions! }
+
+          it "starts and commits a transaction even without any queries" do
+            expect(client).to receive(:query).with("BEGIN").and_return(stub_mysql_client_result)
+            expect(client).to receive(:query).with("COMMIT").and_return(stub_mysql_client_result)
+
+            connection.transaction do
+              expect(connection.current_transaction.materialized?).to be_truthy
+            end
+          end
+        end
+
+        context "with lazy transactions enabled" do
+          before { connection.enable_lazy_transactions! }
+
+          it 'does not start a transaction without any queries' do
+            expect(client).to_not receive(:query).with("BEGIN")
+            expect(client).to_not receive(:query).with("COMMIT")
+
+            connection.transaction do
+              expect(connection.current_transaction.materialized?).to be_falsey
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## [0.2.0] - Unreleased
### Added
- Added support for Rails 6+ by adding knowledge of lazy transactions to the adapter.