### PR TITLE
non-production: set up codecov in this repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,3 +6,4 @@ on:
 jobs:
   tests:
     uses: Invoca/ruby-test-matrix-workflow/.github/workflows/ruby-test-matrix.yml@main
+    secrets: inherit

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 gem 'appraisal'
 gem 'appraisal-matrix'
 gem 'base64'
-gem 'coveralls', require: false
 gem 'mutex_m'
 gem 'mysql2',     '~> 0.5'
 gem 'nokogiri'
@@ -16,3 +15,5 @@ gem 'pry'
 gem 'pry-byebug'
 gem 'rake'
 gem 'rspec'
+gem 'simplecov', '~> 0.22', require: false
+gem 'simplecov-lcov', '~> 0.8', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,6 @@ GEM
       fiber-annotation
       io-event (~> 1.6, >= 1.6.5)
     base64 (0.2.0)
-    bigdecimal (3.1.8)
     builder (3.3.0)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -87,12 +86,6 @@ GEM
       fiber-annotation
       fiber-local (~> 1.1)
       json
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.1)
@@ -188,11 +181,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    simplecov (0.16.1)
+    simplecov (0.22.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -200,14 +195,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sync (0.5.0)
-    term-ansicolor (1.11.2)
-      tins (~> 1.0)
     thor (1.3.1)
     timeout (0.4.1)
-    tins (1.33.0)
-      bigdecimal
-      sync
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.6)
@@ -222,7 +211,6 @@ DEPENDENCIES
   appraisal
   appraisal-matrix
   base64
-  coveralls
   fibered_mysql2!
   mutex_m
   mysql2 (~> 0.5)
@@ -231,6 +219,8 @@ DEPENDENCIES
   pry-byebug
   rake
   rspec
+  simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
 
 BUNDLED WITH
    2.6.3

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gem "appraisal"
 gem "appraisal-matrix"
 gem "base64"
-gem "coveralls", require: false
 gem "mutex_m"
 gem "mysql2", "~> 0.5"
 gem "nokogiri"
@@ -13,6 +12,8 @@ gem "pry"
 gem "pry-byebug"
 gem "rake"
 gem "rspec"
+gem "simplecov", "~> 0.22", require: false
+gem "simplecov-lcov", "~> 0.8", require: false
 gem "rails", "~> 6.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gem "appraisal"
 gem "appraisal-matrix"
 gem "base64"
-gem "coveralls", require: false
 gem "mutex_m"
 gem "mysql2", "~> 0.5"
 gem "nokogiri"
@@ -13,6 +12,8 @@ gem "pry"
 gem "pry-byebug"
 gem "rake"
 gem "rspec"
+gem "simplecov", "~> 0.22", require: false
+gem "simplecov-lcov", "~> 0.8", require: false
 gem "rails", "~> 6.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gem "appraisal"
 gem "appraisal-matrix"
 gem "base64"
-gem "coveralls", require: false
 gem "mutex_m"
 gem "mysql2", "~> 0.5"
 gem "nokogiri"
@@ -13,6 +12,8 @@ gem "pry"
 gem "pry-byebug"
 gem "rake"
 gem "rspec"
+gem "simplecov", "~> 0.22", require: false
+gem "simplecov-lcov", "~> 0.8", require: false
 gem "rails", "~> 7.0.0"
 
 gemspec path: "../"

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+unless ENV["NO_COVERAGE"] == "true"
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/spec/"
+    track_files "lib/**/*.rb"
+
+    if ENV["GITHUB_ACTIONS"]
+      require "simplecov-lcov"
+
+      SimpleCov::Formatter::LcovFormatter.config do |config|
+        config.report_with_single_file = true
+        config.single_report_path = "coverage/lcov.info"
+      end
+
+      formatter SimpleCov::Formatter::LcovFormatter
+    else
+      formatter SimpleCov::Formatter::HTMLFormatter
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
-require 'coveralls'
-
-Coveralls.wear!
+require_relative "simplecov_helper"
 
 require 'bundler/setup'
 require 'logger'


### PR DESCRIPTION
## Summary
- Add secrets: inherit to the pipeline workflow call so CODECOV_TOKEN reaches the Codecov upload step in the shared ruby-test-matrix workflow.
- Replace coveralls with simplecov (~> 0.22) + simplecov-lcov (~> 0.8). Coveralls pinned simplecov to ~> 0.16.1, so the two could not coexist; the Coveralls.wear! call in spec_helper.rb was replaced with a spec/simplecov_helper.rb that emits coverage/lcov.info under GITHUB_ACTIONS and HTML locally.
- Update Gemfile.lock and regenerate the appraisal gemfiles (rails_6_0 / rails_6_1 / rails_7_0) for the dependency change.

## Coverage
Measured locally on Ruby 3.2.1: Line Coverage: 86.0% (86 / 100), 29 examples, 0 failures. lcov generation verified with GITHUB_ACTIONS=true.

No codecov.yml added since coverage is above 80%.